### PR TITLE
Simplify the API wrapper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,32 @@ const { TAMAKOAPI } = require("tamako-api");
 // Instantiate the class before you can use it
 // Parameters are only required if you want to use the chatbot method
 // You can get your own username, id, and secret here -> https://appcenter.theskyfallen.com/
+// chatbot parameter is optional
 const tamako = new TAMAKOAPI({
  svcid: process.env.TAMAKO_SERVICEID,
  prvid: process.env.TAMAKO_PRIVATEID,
- svcsecret: process.env.TAMAKO_SECRET
+ svcsecret: process.env.TAMAKO_SECRET,
+ chatbot: {
+   name: "The name for the bot",
+   gender: "The assumed gender of the bot",
+   prefix: "The prefix of your bot",
+   dev: "The creator of your bot (naturally it is you)"
+   }
 });
 
-tamako.chatbot('hello there').then((response) => {
+// Using default values for options found in tamako.cboptions
+tamako.chatbot('hello there', { user: '123456' }).then((response) => {
    console.log(response);
 });
+
+// Using own values without using the options found on tamako.cboptions
+tamako.chatbot('hello there', {
+   name: "The name for the bot",
+   gender: "The assumed gender of the bot",
+   user: "123456",
+   prefix: "The prefix of your bot",
+   dev: "The creator of your bot (naturally it is you)"
+}).then(response => console.log(response));
 
 // Fires whenever an error occurs
 tamako.on("error", error => {
@@ -48,18 +65,18 @@ tamako.on("error", error => {
 
 # Authenticated Functions
 
-## chatbot(message, name, gender, userid)
+## chatbot(message, options)
 Note: Requires authentication
 Returns message sent by the chatbot or undefined (if error occurs)
 
 | Parameter | Type | Default | Optional | Description |
 | - | - | - | :-: | - |
 | message | string | none | ❌ | The message you want the chatbot to reply with
-| name | string | Tamako | ✔️ | The name of the chatbot
-| gender | string | female | ✔️ | The gender of the chatbot
-| userid | string | 123456 | ✔️ | Unique ID to tell users using the endpoint apart
-| prefix | string | Not Set By Developer | ✔️ | It should be your bot's prefix
-| dev | string | Bear#3437 | ✔️ | Name Of the developer of the bot
+| options.name | string | Tamako | ✔️ | The name of the chatbot
+| options.gender | string | female | ✔️ | The gender of the chatbot
+| options.user | string | none | ❌ | Unique ID to tell users using the endpoint apart
+| options.prefix | string | Not Set By Developer | ✔️ | It should be your bot's prefix
+| options.dev | string | Bear#3437 | ✔️ | Name Of the developer of the bot
 
 # Unauthenticated Functions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "tamako-api",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A package for using the Tamako API Easily!",
   "main": "index.js",
   "scripts": {

--- a/src/tamakoapi.js
+++ b/src/tamakoapi.js
@@ -14,13 +14,13 @@ class TAMAKOAPI extends EventEmitter {
         
         // Encode the components on the go while instantiating this constructor
         for (const args of ['svcid', 'prvid', 'svcsecret']){
-            this[args] = options[args] ? encodeURIComponent(option[args]) : undefined;
+            this[args] = options[args] ? encodeURIComponent(options[args]) : undefined;
         };
         
         // Add chatbot's static data directly into the constructor
         this.cboptions = {};
         for (const [args, altr] of [['name', 'Tamako'], ['gender', 'female'], ['prefix', 'Not Set By Developer'], ['dev', 'Bear#3437']]){
-            this.cboptions[args] = (options.chatbot||{})[args] || altr;
+            this.cboptions[args] = encodeURIComponent((options.chatbot||{})[args]) || altr;
         };
     };
 

--- a/src/tamakoapi.js
+++ b/src/tamakoapi.js
@@ -41,7 +41,7 @@ class TAMAKOAPI extends EventEmitter {
      *    gender: 'Female'
      * });
      */ 
-    async chatbot(message, options) {
+    async chatbot(message, options = {}) {
         if (!message) {
             throw new err(`TAMAKOAPI#chatbot: Required message parameter, received none.`);
         };

--- a/src/tamakoapi.js
+++ b/src/tamakoapi.js
@@ -3,8 +3,6 @@ const base = 'http://api.tamako.tech/api'
 const fetch = require("node-fetch");
 const EventEmitter = require("events");
 
-let token;
-
 class TAMAKOAPI extends EventEmitter {
     constructor(options = {}) {
         super();

--- a/src/tamakoapi.js
+++ b/src/tamakoapi.js
@@ -18,9 +18,9 @@ class TAMAKOAPI extends EventEmitter {
         };
         
         // Add chatbot's static data directly into the constructor
-        this.chatbot = {};
+        this.cboptions = {};
         for (const [args, altr] of [['name', 'Tamako'], ['gender', 'female'], ['prefix', 'Not Set By Developer'], ['dev', 'Bear#3437']]){
-            this.chatbot[args] = (options.chatbot||{})[args] || altr;
+            this.cboptions[args] = (options.chatbot||{})[args] || altr;
         };
     };
 
@@ -54,7 +54,7 @@ class TAMAKOAPI extends EventEmitter {
             } else if (prop === 'user' && !options[prop]){
                 throw new err(`TAMAKOAPI#chatbot: options.user: This field is required.`);
             } else {
-                param.push(`${prop}=${options[prop] ? encodeURIComponent(options[prop]) : this.chatbot[prop]}`);
+                param.push(`${prop}=${options[prop] ? encodeURIComponent(options[prop]) : this.cboptions[prop]}`);
             };
         };
         


### PR DESCRIPTION
This PR introduces
- [x] Removal of redundant codes.
- [x] Class now accpets parameters from previous version to set them as default via options.chatbot.
- [x] chatbot method now accepts an object instead of multiple trailing parameters. (Will break previous codes)
- [x] chatbot now only requires at least the user ID to perform a successful request to the chatbot endpoint.  
- [x] async methods now return an actual usable Promise object as opposed to previously Promise{<void>}.
- [x] all non authenticated endpoint now uses an internal private method __fetch.
- [x] This wrapper now returns a "Not Found" Error when response object received from API is full of null values. [Example](https://api.tamako.tech/api/pokedex?pokemon=)

Note: This PR has not been tested yet, but should work "in theory". Do not merge immediately and test the PR yourself first.